### PR TITLE
support optional tesnor for batch_norm_grad composite logic

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -1213,8 +1213,8 @@ void scatter_grad(const Tensor& index,
 
 template <typename T>
 void batch_norm_grad(const Tensor& x,
-                     const Tensor& scale,
-                     const Tensor& bias,
+                     const paddle::optional<Tensor>& scale,
+                     const paddle::optional<Tensor>& bias,
                      const paddle::optional<Tensor>& mean_out,
                      const paddle::optional<Tensor>& variance_out,
                      const Tensor& saved_mean,
@@ -1307,14 +1307,20 @@ void batch_norm_grad(const Tensor& x,
 
       if (x_grad) {
         if (use_global_stats) {
-          auto nhwc_x_grad = scale * rsqrt_var * nhwc_out_grad;
+          auto nhwc_x_grad = rsqrt_var * nhwc_out_grad;
+          if (scale) {
+            nhwc_x_grad = scale.get() * nhwc_x_grad;
+          }
           auto nchw_x_grad = transpose<T>(nhwc_x_grad, nhwc_to_nchw_dim);
           if (need_cast) {
             nchw_x_grad = cast<T>(nchw_x_grad, x.dtype());
           }
           set_output<T>(nchw_x_grad, x_grad);
         } else {
-          auto part1 = scale * rsqrt_var;
+          auto part1 = rsqrt_var;
+          if (scale) {
+            part1 = scale.get() * part1;
+          }
           auto mean_temp1 = nhwc_out_grad_sum / nhw;
           auto mean_temp2 = sum_dout_mul_diff / nhw * rsqrt_var * rsqrt_var;
           auto part2 =
@@ -1344,14 +1350,19 @@ void batch_norm_grad(const Tensor& x,
         auto nhwc_sum_dout_mul_diff = sum<T>(
             out_grad_data * (x_data - mean_data), reduce_axis, dtype, false);
         if (use_global_stats) {
-          auto x_grad_data = scale * rsqrt_var * out_grad_data;
+          auto x_grad_data = rsqrt_var * out_grad_data;
+          if (scale) {
+            x_grad_data = scale.get() * x_grad_data;
+          }
           if (need_cast) {
             x_grad_data = cast<T>(x_grad_data, x.dtype());
           }
           set_output<T>(x_grad_data, x_grad);
         } else {
-          auto part1 = scale * rsqrt_var;
-
+          auto part1 = rsqrt_var;
+          if (scale) {
+            part1 = scale.get() * part1;
+          }
           auto mean_temp1 = out_grad_data_sum / nhw;
           auto mean_temp2 =
               nhwc_sum_dout_mul_diff / nhw * rsqrt_var * rsqrt_var;

--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -99,7 +99,7 @@
     func : batch_norm_grad
     data_type : out_grad
   optional : scale, bias, mean_out, variance_out, reserve_space
-  #composite: batch_norm_grad(x, scale, bias, mean_out, variance_out, saved_mean, saved_variance, reserve_space, out_grad, momentum, epsilon, data_layout, is_test, use_global_stats, trainable_statistics)
+  composite: batch_norm_grad(x, scale, bias, mean_out, variance_out, saved_mean, saved_variance, reserve_space, out_grad, momentum, epsilon, data_layout, is_test, use_global_stats, trainable_statistics)
   backward : batch_norm_double_grad
 
 - backward_op : c_embedding_grad


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what you’ve done -->
Pcard-66975

support optional tensor for batch_norm composite logic